### PR TITLE
fix: Use shellescape for command line arguments

### DIFF
--- a/autoload/openai.vim
+++ b/autoload/openai.vim
@@ -31,9 +31,10 @@ function! openai#Complete()
 	" Curl the OpenAI API and pipe the result to jq.
 	let openai_api_key = $OPENAI_API_KEY
 	" TODO: iterate over choices.
-	let command = "curl -sSL -H 'Content-Type: application/json' -H 'Authorization: Bearer " . openai_api_key . "' -d '{\"prompt\":\"" . substitute(trim(text), '"', '\\"', "g") . "\", \"max_tokens\": 100}' https://api.openai.com/v1/engines/davinci/completions"
+    let payload = shellescape("{\"prompt\":\"" . substitute(trim(text), '"', '\\"', "g") . "\", \"max_tokens\": 100}")
+	let command = "curl -sSL -H 'Content-Type: application/json' -H 'Authorization: Bearer " . openai_api_key . "' -d " . payload . " https://api.openai.com/v1/engines/davinci/completions"
 	let curl_output = trim(system(command))
-	let output = trim(system("echo '" . curl_output . "' | jq --raw-output .choices[0].text"))
+	let output = trim(system("echo " . shellescape(curl_output) . " | jq --raw-output .choices[0].text"))
 
 	" Append the text back to the selection or current line.
 	call append(end_line, split(output, "\n"))

--- a/autoload/openai.vim
+++ b/autoload/openai.vim
@@ -31,7 +31,7 @@ function! openai#Complete()
 	" Curl the OpenAI API and pipe the result to jq.
 	let openai_api_key = $OPENAI_API_KEY
 	" TODO: iterate over choices.
-    let payload = shellescape("{\"prompt\":\"" . substitute(trim(text), '"', '\\"', "g") . "\", \"max_tokens\": 100}")
+	let payload = shellescape("{\"prompt\":\"" . substitute(trim(text), '"', '\\"', "g") . "\", \"max_tokens\": 100}")
 	let command = "curl -sSL -H 'Content-Type: application/json' -H 'Authorization: Bearer " . openai_api_key . "' -d " . payload . " https://api.openai.com/v1/engines/davinci/completions"
 	let curl_output = trim(system(command))
 	let output = trim(system("echo " . shellescape(curl_output) . " | jq --raw-output .choices[0].text"))


### PR DESCRIPTION
Trying to kill us all, I swear! Haha.

I'm not sure how this didn't cause any issues for you. I am using Fish as my main shell but I think the escaping rules being tripped up by single quotes in the arguments would translate to Bash and most other shells.

...Not really expecting you to merge this since it looks like a dead project. But at least the pull request is here for anyone else who wants to try out the plugin and checks the pulls before fixing the issue themselves.